### PR TITLE
Added budget to help us keep people with slow data plans in mind during dev

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -43,7 +43,13 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.prod.ts"
                 }
-              ]
+              ],
+              "budgets": [{
+                "type": "bundle",
+                "name": "main",
+                "maximumWarning": "1mb",
+                "maximumError": "2mb"
+              }]
             }
           }
         },


### PR DESCRIPTION
Now when we run `ng build --prod` we will get a warning if the main bundle exceeds 1 mb or an error if it exceeds 2mb.  

It was discussed in issue #3 that we would like to keep people with slow/restrictive data plans in mind during development, and this should help us with that.